### PR TITLE
Create openam-ldap-injection.yaml

### DIFF
--- a/vulnerabilities/openam-ldap-injection.yaml
+++ b/vulnerabilities/openam-ldap-injection.yaml
@@ -1,0 +1,24 @@
+id: openam-ldap-injection
+
+info:
+  name: LDAP Injection In OPENAM
+  author: xelkomy
+  severity: high
+  description: The vulnerability was found in the password reset feature that OpenAM provides. When a user tries to reset his password, he is asked to enter his username then the backend validates whether the user exists or not through an LDAP query before the password reset token is sent to the user’s email.
+  
+  # reference: https://blog.cybercastle.io/ldap-injection-in-openam/
+
+requests:
+  - method: GET
+    path:
+      - '{{BaseURL}/openam/ui/PWResetUserValidation'
+      - '{{BaseURL}/ui/PWResetUserValidation'
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+      - type: word
+        words:
+          - "jato.defaultCommand"
+        part: body


### PR DESCRIPTION
reference: https://blog.cybercastle.io/ldap-injection-in-openam/

The vulnerability was found in the password reset feature that OpenAM provides. When a user tries to reset his password, he is asked to enter his username then the backend validates whether the user exists or not through an LDAP query before the password reset token is sent to the user’s email.